### PR TITLE
Setup docker and simple vector store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -26,3 +26,19 @@ cd backend
 pip install -r requirements.txt
 pytest
 ```
+
+## Docker
+
+To run the API using Docker:
+
+```bash
+docker build -t rag-codex .
+docker run -p 8000:8000 rag-codex
+```
+
+Alternatively you can use docker-compose:
+
+```bash
+docker-compose up --build
+```
+

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, UploadFile, File, Depends
 from typing import List
 
+from app.services.vector_store import vector_store
+
 router = APIRouter(prefix="/documents", tags=["documents"])
 
 db_documents = []
@@ -10,6 +12,7 @@ def upload_document(file: UploadFile = File(...), user_id: int = 1):
     text = file.file.read().decode("utf-8")
     doc = {"id": len(db_documents) + 1, "user_id": user_id, "filename": file.filename, "text": text}
     db_documents.append(doc)
+    vector_store.add_document(text)
     return doc
 
 @router.get("/")

--- a/backend/app/routers/rag.py
+++ b/backend/app/routers/rag.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter
 
+from app.services.vector_store import vector_store
+
 router = APIRouter(prefix="/rag", tags=["rag"])
 
 @router.post("/chat")
 def chat(query: str, user_id: int = 1):
-    # Placeholder chat logic
-    return {"answer": f"You asked: {query}"}
+    """Return content of the most relevant document for the query."""
+    answer = vector_store.query(query)
+    return {"answer": answer}

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -1,12 +1,32 @@
-"""Placeholder vector store implementation."""
+"""Very small in-memory vector store using TF-IDF."""
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
 
 class VectorStore:
-    def __init__(self):
-        self.documents = []
+    """Simple TF‑IDF based vector store for demo purposes."""
 
-    def add_document(self, text: str):
-        self.documents.append(text)
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+        self.vectorizer = TfidfVectorizer()
+        self.vectors = None
 
-    def query(self, q: str) -> str:
-        # Fake retrieval
-        return "".join(self.documents)
+    def add_document(self, text: str) -> None:
+        """Add a new document to the store."""
+        self.texts.append(text)
+        self.vectors = self.vectorizer.fit_transform(self.texts)
+
+    def query(self, q: str, top_k: int = 1) -> str:
+        """Return concatenated top documents for a query."""
+        if not self.texts:
+            return ""
+
+        q_vec = self.vectorizer.transform([q])
+        sims = cosine_similarity(q_vec, self.vectors).flatten()
+        best_idx = sims.argsort()[-top_k:][::-1]
+        return " ".join(self.texts[i] for i in best_idx)
+
+
+# Global store used by routers
+vector_store = VectorStore()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic
 httpx
 email-validator
 python-multipart
+scikit-learn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  backend:
+    build: .
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- add a Dockerfile and docker-compose for running the FastAPI backend
- expand README with Docker usage instructions
- implement a simple TF‑IDF based vector store using `scikit-learn`
- hook document upload and RAG chat endpoints to the vector store
- update backend requirements

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fde53a84832cbb1b7e8bd5b56220